### PR TITLE
Windows fixes (requires cygpath, bash, and make).

### DIFF
--- a/firmware/version_data.sh
+++ b/firmware/version_data.sh
@@ -7,8 +7,8 @@ COMMIT="$(git log --format="%H" -n 1)"
 BRANCH="$(git symbolic-ref --short HEAD)"
 DESCRIBE="$(git describe --dirty)"
 
-TMPFILE_H=$(tempfile -s .h)
-TMPFILE_C=$(tempfile -s .c)
+TMPFILE_H=$(tempfile -s .h | mktemp --suffix=.h)
+TMPFILE_C=$(tempfile -s .c | mktemp --suffix=.c)
 
 UPLATFORM="$(echo $PLATFORM | tr '[:lower:]' '[:upper:]')"
 UTARGET="$(echo $TARGET | tr '[:lower:]' '[:upper:]')"

--- a/gateware/git_info.py
+++ b/gateware/git_info.py
@@ -8,10 +8,10 @@ from litex.soc.interconnect.csr import *
 
 def git_root():
     if sys.platform == "win32":
-	# Git on Windows is likely to use Unix-style paths (`/c/path/to/repo`),
-	# whereas directories passed to Python should be Windows-style paths
-	# (`C:/path/to/repo`) (because Python calls into the Windows API). 
-	# `cygpath` converts between the two.
+        # Git on Windows is likely to use Unix-style paths (`/c/path/to/repo`),
+        # whereas directories passed to Python should be Windows-style paths
+        # (`C:/path/to/repo`) (because Python calls into the Windows API). 
+        # `cygpath` converts between the two.
         git = subprocess.Popen(
             "git rev-parse --show-toplevel",
             cwd=os.path.dirname(__file__),

--- a/gateware/git_info.py
+++ b/gateware/git_info.py
@@ -8,6 +8,10 @@ from litex.soc.interconnect.csr import *
 
 def git_root():
     if sys.platform == "win32":
+	# Git on Windows is likely to use Unix-style paths (`/c/path/to/repo`),
+	# whereas directories passed to Python should be Windows-style paths
+	# (`C:/path/to/repo`) (because Python calls into the Windows API). 
+	# `cygpath` converts between the two.
         git = subprocess.Popen(
             "git rev-parse --show-toplevel",
             cwd=os.path.dirname(__file__),

--- a/gateware/git_info.py
+++ b/gateware/git_info.py
@@ -1,16 +1,30 @@
 import binascii
 import os
 import subprocess
+import sys
 
 from litex.gen.fhdl import *
 from litex.soc.interconnect.csr import *
 
 def git_root():
-    return subprocess.check_output(
-        "git rev-parse --show-toplevel",
-        shell=True,
-        cwd=os.path.dirname(__file__),
-    ).decode('ascii').strip() 
+    if sys.platform == "win32":
+        git = subprocess.Popen(
+            "git rev-parse --show-toplevel",
+            cwd=os.path.dirname(__file__),
+            stdout=subprocess.PIPE,
+        )
+        path = subprocess.check_output(
+            "cygpath -wf -",
+            stdin=git.stdout,
+        )
+        git.wait()
+        return path.decode('ascii').strip()
+    else:
+        return subprocess.check_output(
+            "git rev-parse --show-toplevel",
+            shell=True,
+            cwd=os.path.dirname(__file__),
+        ).decode('ascii').strip()
 
 def git_commit():
     data = subprocess.check_output(


### PR DESCRIPTION
This is a small commit to make building on Windows, at least with MSYS2 and bash, fully supported.

Git on Windows is likely to use Unix-style paths (`/c/path/to/repo`), whereas directories passed to Python should be Windows-style paths (`C:/path/to/repo`) (because Python calls into the Windows API). `cygpath` converts between the two.

Additionally, `tempfile` doesn't exist on bash on Windows, so I just force a call to `mktemp`, which does exist, if `tempfile` fails. The error message (`tempfile not found`) is misleading in the sense that the script does _not_ fail, but I'm unsure of a better solution at the moment.