### PR TITLE
Makefile: Add option to choose python interpreter binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ ifeq ($(HDMI2USB_ENV),)
 endif
 endif
 
+PYTHON ?= python
+export PYTHON
+
 PLATFORM ?= opsis
 export PLATFORM
 # Default board
@@ -37,7 +40,7 @@ export PYTHONHASHSEED
 # ---------------------------------
 
 MAKE_CMD=\
-	time python -u ./make.py \
+	time $(PYTHON) -u ./make.py \
 		--platform=$(PLATFORM) \
 		--target=$(TARGET) \
 		--cpu-type=$(CPU) \

--- a/targets/mimasv2/Makefile.mk
+++ b/targets/mimasv2/Makefile.mk
@@ -11,11 +11,11 @@ gateware-load-mimasv2:
 	@false
 
 gateware-flash-mimasv2:
-	python3 $$(which MimasV2Config.py) $(PORT) $(TARGET_BUILD_DIR)/gateware/top.bin
+	$(PYTHON) $$(which MimasV2Config.py) $(PORT) $(TARGET_BUILD_DIR)/gateware/top.bin
 
 image-flash-mimasv2:
-	python mkimage.py
-	python3 $$(which MimasV2Config.py) $(PORT) $(TARGET_BUILD_DIR)/flash.bin
+	$(PYTHON) mkimage.py
+	$(PYTHON) $$(which MimasV2Config.py) $(PORT) $(TARGET_BUILD_DIR)/flash.bin
 
 firmware-load-mimasv2:
 	flterm --port=$(PORT) --kernel=$(TARGET_BUILD_DIR)/software/firmware/firmware.bin --speed=$(BAUD)


### PR DESCRIPTION
This was a pull request I totally forgot about. The `python3` interpreter may not be called `python` on some machines, as is the case for MSYS2, so I added some Makefile logic to override the interpreter name.